### PR TITLE
Support SSL over HAProxy

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -25,7 +25,7 @@ defaults
     errorfile 504 /etc/haproxy/errors/504.http
 
 listen monitor
-    bind {{ haproxy_vip | mandatory }}:9300
+    bind {{ keepalived_haproxy_vip | mandatory }}:9300
     mode http
     monitor-uri /status
     stats enable
@@ -34,14 +34,20 @@ listen monitor
     stats auth {{ haproxy_stats_auth_user | default("admin@sbs") }}:{{ haproxy_stats_auth_pass | default("sbs@jio") }}
     stats refresh {{ haproxy_stats_refresh | default("5s") }}
 
+frontend https-cinder
+    bind *:443 ssl crt {{ sbs_haproxy_ssl_pem }}
+    reqadd X-Forwarded-Proto:\ https
+    default_backend cinder-ec2-api
+
 frontend vip-cinder
-    bind {{ haproxy_vip | mandatory }}:{{ haproxy_cinder_api_port | default("81") }}
+    bind {{ keepalived_haproxy_vip | mandatory }}:{{ haproxy_cinder_api_port | default("81") }}
     default_backend cinder-api
 
 backend cinder-api
     balance roundrobin
+    default-server inter 1s
     {% for cinder_api_host in cinder_api_hosts %}
-    server {{ cinder_api_host.host }} {{ cinder_api_host.ip }}:8776 check inter 1s
+    server {{ cinder_api_host.host }} {{ cinder_api_host.ip }}:8776 check
     {% endfor %}
 
 frontend vip-galera
@@ -61,11 +67,14 @@ backend galera-vms
     {% endfor %}
 
 frontend vip-cinder-ec2
-    bind {{ haproxy_vip | mandatory }}:{{ haproxy_cinder_ec2_api_port | default("82") }}
+    bind {{ keepalived_haproxy_vip | mandatory }}:{{ haproxy_cinder_ec2_api_port | default("80") }}
+    reqadd X-Forwarded-Proto:\ http
     default_backend cinder-ec2-api
 
 backend cinder-ec2-api
+    redirect scheme https if !{ ssl_fc }
     balance roundrobin
+    default-server inter 1s
     {% for cinder_ec2_api_host in cinder_ec2_api_hosts %}
-    server {{ cinder_ec2_api_host.host }} {{ cinder_ec2_api_host.ip }}:8788 check inter 1s
+    server {{ cinder_ec2_api_host.host }} {{ cinder_ec2_api_host.ip }}:8788 check
     {% endfor %}

--- a/keepalived.conf
+++ b/keepalived.conf
@@ -21,7 +21,7 @@ vrrp_instance VI_01 {
     priority {{ keepalived_priority | default("100") }}
     # The virtual ip address shared between the two load balancers
     virtual_ipaddress {
-        {{ keepalived_vip | mandatory }}
+        {{ keepalived_haproxy_vip | mandatory }}
     }
     track_script {
         check_haproxy


### PR DESCRIPTION
* Added configuration for SSL over Haproxy. Haproxy would cater to
SSL domain requests. Plain http requests would be redirected to SSL
domain.
* Haproxy does LB for c-ec2-api, c-api, galera. So, single VIP
'keepalived_haproxy_vip' is enough for its failover. Propagated this
variable name in all config files.
* Specified 'inter 1s' common to all server nodes in a backend.

Closes-Bug: #JBS-96