### PR TITLE
cinder volume HA

### DIFF
--- a/cinder.conf
+++ b/cinder.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 rpc_zmq_host=<hostname>
+rpc_zmq_vol_vip=<volume_vip_hostname>
 rpc_zmq_matchmaker=ring
 rpc_backend=zmq
 rpc_zmq_ipc_dir=/var/run/cinder


### PR DESCRIPTION
Added new config option to support cinder volume HA

Note - This option and patch(https://github.com/JioCloud/cinder/pull/43)
can be removed after we move to active active configuration.

Closes-Bug: #JBS-105