### PR TITLE
Upates to ceph.conf for backfill, recovery and mkfs

### DIFF
--- a/ceph/ceph.conf
+++ b/ceph/ceph.conf
@@ -14,9 +14,9 @@ filestore_fd_cache_shards = 32
 osd_pool_default_size = {{osd_pool_default_size}}
 osd_pool_default_min_size = 2
 
-
 [mon]
 mon osd allow primary affinity = true
+mon osd down out subtree limit = host
 
 [osd]
 osd_journal_size = 10000

--- a/ceph/ceph.conf
+++ b/ceph/ceph.conf
@@ -14,6 +14,7 @@ filestore_fd_cache_shards = 32
 osd_pool_default_size = {{osd_pool_default_size}}
 osd_pool_default_min_size = 2
 
+
 [mon]
 mon osd allow primary affinity = true
 
@@ -22,3 +23,12 @@ osd_journal_size = 10000
 osd_op_threads = 5
 osd_op_num_threads_per_shard = 1
 osd_op_num_shards = 25
+osd client op priority = 63
+osd max backfills = 1
+osd recovery threads = 1
+osd recovery op priority = 1
+osd recovery max active = 1
+osd max scrubs = 1
+osd mkfs type = xfs
+osd mkfs options xfs = -k
+osd mount options xfs = rw,noatime,inode64


### PR DESCRIPTION
Reduce backfill, recovery and scrub priorities, and increase
client io priority

Also added mkfs options to increase performance

For more info on each of the options refer:
http://docs.ceph.com/docs/hammer/rados/configuration/osd-config-ref

Signed-off-by: shishir gowda <shishir.gowda@ril.com>