### PR TITLE
Cinder volume active passive failover issue

### DIFF
--- a/keepalived.conf
+++ b/keepalived.conf
@@ -9,7 +9,7 @@ vrrp_script check_haproxy {
 
 # Script used to check if cinder-volume is running
 vrrp_script check_c_vol {
-           script "/usr/bin/killall -0 cinder-volume"
+           script "sudo /usr/local/bin/keepalivedtrack.sh"
            interval 1
 }
 

--- a/keepalivednotify.sh
+++ b/keepalivednotify.sh
@@ -6,9 +6,13 @@ STATE=$3
 
 case $STATE in
         "MASTER") service cinder-volume start
+                  rm /var/run/keepalived.state.*
+                  touch /var/run/keepalived.state.master
                   exit 0
                   ;;
         "BACKUP") service cinder-volume stop
+                  rm /var/run/keepalived.state.*
+                  touch /var/run/keepalived.state.backup
                   exit 0
                   ;;
 esac

--- a/keepalivedtrack.sh
+++ b/keepalivedtrack.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -e "/var/run/keepalived.state.backup" ]
+then
+    exit 0
+fi
+/usr/bin/killall -0 cinder-volume


### PR DESCRIPTION
when a node is in backup state, we dont want the c-vol service to be
running and we stop it. But this causes a side effect, wherein the node
switched to fault state as the keepalived health check script failed.
This side effect prevents the node from auto-transition to master state
during failover. so i've disabled the health check when the node is in
backup state.

Closes-Bug: #JBS-80