### PR TITLE
Separate keepalived deployment for haproxy & c-vol

### DIFF
--- a/keepalived_c-vol.conf
+++ b/keepalived_c-vol.conf
@@ -3,7 +3,7 @@ global_defs {
 }
 # Script used to check if cinder-volume is running
 vrrp_script check_c_vol {
-           script "/usr/bin/killall -0 cinder-volume"
+           script "sudo /usr/local/bin/keepalivedtrack.sh"
            interval 1
 }
 

--- a/keepalived_c-vol.conf
+++ b/keepalived_c-vol.conf
@@ -1,0 +1,27 @@
+global_defs {
+    router_id {{ hostname | mandatory }}
+}
+# Script used to check if cinder-volume is running
+vrrp_script check_c_vol {
+           script "/usr/bin/killall -0 cinder-volume"
+           interval 1
+}
+
+vrrp_instance VI_01 {
+    state {{ keepalived_vol_state | default("BACKUP") }}
+    interface {{ keepalived_vol_interface | mandatory }}
+    virtual_router_id {{ keepalived_vol_virtual_router_id | default("87") }}
+    priority {{ keepalived_priority | default("100") }}
+    # The virtual ip address shared between the two load balancers
+    virtual_ipaddress {
+        {{ keepalived_vol_vip | mandatory }}
+    }
+    track_script {
+        check_c_vol
+    }
+    authentication {
+        auth_type PASS
+        auth_pass {{ keepalived_vol_auth_pass | default("sbsvol@jio") }}
+    }
+    notify /usr/local/bin/keepalivednotify.sh
+}

--- a/keepalived_haproxy.conf
+++ b/keepalived_haproxy.conf
@@ -1,0 +1,27 @@
+global_defs {
+    router_id {{ hostname | mandatory }}
+}
+# Script used to check if HAProxy is running
+vrrp_script check_haproxy {
+    script "/usr/bin/killall -0 haproxy"
+    interval 1
+}
+
+# The priority specifies the order in which the assigned interface to take over in a failover
+vrrp_instance VI_01 {
+    state {{ keepalived_state | default("BACKUP") }}
+    interface {{ keepalived_interface | mandatory }}
+    virtual_router_id {{ keepalived_virtual_router_id | default("86") }}
+    priority {{ keepalived_priority | default("100") }}
+    # The virtual ip address shared between the two load balancers
+    virtual_ipaddress {
+        {{ keepalived_haproxy_vip | mandatory }}
+    }
+    track_script {
+        check_haproxy
+    }
+    authentication {
+        auth_type PASS
+        auth_pass {{ keepalived_auth_pass | default("sbs@jio") }}
+    }
+}


### PR DESCRIPTION
Haproxy and c-vol services are deployed in different node triplets in prod.
So, add support for independent deployment of keepalived
for both those services in ansible.

Closes-Bug: #JBS-128