### PR TITLE
Tune rados_connect_timeout

### DIFF
--- a/cinder.conf
+++ b/cinder.conf
@@ -1,6 +1,0 @@
-[DEFAULT]
-rpc_zmq_host=<hostname>
-rpc_zmq_vol_vip=<volume_vip_hostname>
-rpc_zmq_matchmaker=ring
-rpc_backend=zmq
-rpc_zmq_ipc_dir=/var/run/cinder

--- a/cinder/cinder.conf
+++ b/cinder/cinder.conf
@@ -85,6 +85,6 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 rbd_flatten_volume_from_snapshot=false
 rbd_max_clone_depth=5
 rbd_store_chunk_size=4
-rados_connect_timeout=-1
+rados_connect_timeout=60
 rbd_user=cinder
 rbd_secret_uuid= {{ secret_uuid }}


### PR DESCRIPTION
Deleted a duplicate cinder.conf and set the timeout in cinder.conf to 60s.
This is a good first step away from infinite timeout.
We'll refine the value in the due course of time.

The reason for setting this timeout was a recent production issue where
volumes couldn't be created for an hour due to connection latency.

Closes-Bug: #JBS-352 , #JBS-149 , #JBS-353

More details in the below mail thread:
<snip>
...
From: Souvik Ray
Sent: 10 May 2016 18:32
To: Anshul S Jain
Cc: Ravikanth Maddikonda; Chirag Aggarwal; JioCloud SBSTeam; Abhishek Mehrotra; Vishnu1 Kumar; Anant Kaushik; Akash Agrawal
Subject: Re: [PROD] SBS Volumes unreachable - even instance creation, termination failing

Please find the detailed RCA for today’s events. Let me know if you have any questions.

Summary
Threading issues in Cinder Volume component caused SBS Outage. Multi threading using eventlet did not run as expected.  One blocked thread impacted all other threads in Cinder Volume because it was not yielding itself.

Events
From 10:40AM to 11:40 AM, SBS encountered multiple problems in the following volume workflows
CreateVolume
DeleteVolume
AttachVolume
DetachVolume
Creating and Deleting volumes were taking a long time…
Attach and Detach Calls were failing.

A brief design
Cinder API is the API layer which receives call from Compute.
Cinder API forwards request to Cinder-Volume which runs only on Active - Passive mode.
There is only one worker (single process) in Cinder-Volume component
The Cinder-Volume has a thread pool using python eventlet. (128 for delete and 128 for all others). This was done to achieve concurrency in Cinder-Volume . Eventlet threads have known problems for scheduling.
Cinder volume uses RBD to connect to Ceph for all volume operations (create, delete, attach and detach)
There is no RADOS connection timeout (Ceph) in RBD configured.

Key facts in today’s events
Cinder Volume did not accept any new Request from Cinder API for one whole hour.
There were no logs in Cinder Volume component from 10:40 to 11:40.
There were no errors/faults/failures during this particular time.
One create volume call and another delete volume call took 1 hour to complete in Cinder-Volume component. This is an anomaly. Typically it takes  1-5 seconds @P99

Root cause
During the create call in Cinder Volume, the concerned eventlet thread got hung during connecting to Ceph. This continued for an hour.
Context switching to other threads did not happen during the same time. All other threads were also blocked during behind this. This is not an acceptable scenario.
This made Cinder-Volume to go in a state of limbo.
We are investigating why connecting to Ceph took so much time, but the bigger problem is when a eventlet thread is blocked, it is not yielding itself for other threads to run.This eventlet scheduling issue is linked to some of our failures in the past.

Action Items
We are introducing timeouts during RADOS connection. This will ensure that cinder-volume is not hung for a such a long time and fail gracefully. JBS-353
...
</snip>