### PR TITLE
Increase rados_connect_timeout

### DIFF
--- a/cinder/cinder.conf
+++ b/cinder/cinder.conf
@@ -85,6 +85,6 @@ rbd_ceph_conf=/etc/ceph/ceph.conf
 rbd_flatten_volume_from_snapshot=false
 rbd_max_clone_depth=5
 rbd_store_chunk_size=4
-rados_connect_timeout=60
+rados_connect_timeout=300
 rbd_user=cinder
 rbd_secret_uuid= {{ secret_uuid }}


### PR DESCRIPTION
Set the timeout in cinder.conf to 300s.
<snip>
vivekdhayaal [12:42 PM]
chirag.aggarwal: for tuning rados_connect_timeout....
we had said we 'll start with 60sec...but in today's meeting 300sec was discussed...
so shall i change 60sec to 300sec and submit another patch?

chirag.aggarwal [12:42 PM]
300 sec
will later reduce it

shishirng [12:42 PM]
agreed..300sec, as we dont have any data
</snip>

Closes-Bug: #JBS-149